### PR TITLE
Entity id patch

### DIFF
--- a/custom_components/redback_tech/binary_sensor.py
+++ b/custom_components/redback_tech/binary_sensor.py
@@ -56,9 +56,9 @@ class RedbackTechBinarySensorEntity(CoordinatorEntity, BinarySensorEntity):
             "number.rb"
             + self.ent_id[:4]
             + "_"
-            + self.ent_id[-3:].lower()
+            + self.ent_id[-3:].lower().replace(" ", "_")
             + "_"
-            + ENTITY_DETAILS[self.ent_key[7:]]["name"]
+            + ENTITY_DETAILS[self.ent_key[7:]]["name"].lower().replace(" ", "_")
         )
         LOGGER.debug(f"number_data1: {self.ent_data}")
         LOGGER.debug(f"number_data2: {self.ent_id}")

--- a/custom_components/redback_tech/button.py
+++ b/custom_components/redback_tech/button.py
@@ -211,9 +211,9 @@ class RedbackTechButtonEntity(CoordinatorEntity, ButtonEntity):
             "button.rb"
             + self.ent_id[:4]
             + "_"
-            + self.ent_id[-3:].lower()
+            + self.ent_id[-3:].lower().replace(" ", "_")
             + "_"
-            + ENTITY_DETAILS[self.ent_key[7:]]["name"]
+            + ENTITY_DETAILS[self.ent_key[7:]]["name"].lower().replace(" ", "_")
         )
         LOGGER.debug("datetime_data2: %s", self.ent_id)
 
@@ -341,9 +341,9 @@ class RedbackTechButtonEnvelopeEntity(CoordinatorEntity, ButtonEntity):
             "button.rb"
             + self.ent_id[:4]
             + "_"
-            + self.ent_id[-3:].lower()
+            + self.ent_id[-3:].lower().replace(" ", "_")
             + "_"
-            + ENTITY_ENVELOPE_DETAILS[self.ent_key[7:]]["name"]
+            + ENTITY_ENVELOPE_DETAILS[self.ent_key[7:]]["name"].lower().replace(" ", "_")
         )
 
     @property

--- a/custom_components/redback_tech/calendar.py
+++ b/custom_components/redback_tech/calendar.py
@@ -69,7 +69,7 @@ class RedbackTechCalendarEntity(CoordinatorEntity, CalendarEntity):
         super().__init__(coordinator)
         self.ent_id = entity
         # self.ent_key = entity_key
-        self.entity_id = "calendar.rb_" + redback_devices[self.ent_id].serial_number
+        self.entity_id = "calendar.rb_" + (redback_devices[self.ent_id].serial_number).lower().replace(" ", "_")
         self.calendar_details = calendar_details
         self._entity = entity
         LOGGER.debug("calendar entity_id: %s", self.entity_id)

--- a/custom_components/redback_tech/datetime.py
+++ b/custom_components/redback_tech/datetime.py
@@ -53,11 +53,11 @@ class RedbackTechDateTimeEntity(CoordinatorEntity, DateTimeEntity):
         self.ent_key = entity_key
         self.entity_id = (
             "datetime.rb"
-            + self.ent_id[:4]
+            + self.ent_id[:4].lower().replace(" ", "_")
             + "_"
-            + self.ent_id[-3:].lower()
+            + self.ent_id[-3:].lower().replace(" ", "_")
             + "_"
-            + self.ent_key
+            + self.ent_key.lower().replace(" ", "_")
         )
 
     @property

--- a/custom_components/redback_tech/number.py
+++ b/custom_components/redback_tech/number.py
@@ -54,9 +54,9 @@ class RedbackTechNumberEntity(CoordinatorEntity, NumberEntity):
             "number.rb"
             + self.ent_id[:4]
             + "_"
-            + self.ent_id[-3:].lower()
+            + self.ent_id[-3:].lower().replace(" ", "_")
             + "_"
-            + ENTITY_DETAILS[self.ent_key[7:]]["name"]
+            + ENTITY_DETAILS[self.ent_key[7:]]["name"].lower().replace(" ", "_")
         )
         LOGGER.debug("number_data1: %s", self.ent_data)
         LOGGER.debug("number_data2: %s", self.ent_id)

--- a/custom_components/redback_tech/select.py
+++ b/custom_components/redback_tech/select.py
@@ -52,9 +52,9 @@ class RedbackTechSelectsEntity(CoordinatorEntity, SelectEntity):
             "select.rb"
             + self.ent_id[:4]
             + "_"
-            + self.ent_id[-3:].lower()
+            + self.ent_id[-3:].lower().replace(" ", "_")
             + "_"
-            + ENTITY_DETAILS[self.ent_key[7:]]["name"]
+            + ENTITY_DETAILS[self.ent_key[7:]]["name"].lower().replace(" ", "_")
         )
         LOGGER.debug(f"select_data1: {self.ent_data}")
         LOGGER.debug(f"select_data2: {self.ent_id}")

--- a/custom_components/redback_tech/sensor.py
+++ b/custom_components/redback_tech/sensor.py
@@ -55,9 +55,9 @@ class RedbackTechSensorEntity(CoordinatorEntity, SensorEntity):
             "sensor.rb"
             + self.ent_id[:4]
             + "_"
-            + self.ent_id[-3:].lower()
+            + self.ent_id[-3:].lower().replace(" ", "_")
             + "_"
-            + ENTITY_DETAILS[self.ent_key[7:]]["name"]
+            + ENTITY_DETAILS[self.ent_key[7:]]["name"].lower().replace(" ", "_")
         )
 
     @property

--- a/custom_components/redback_tech/text.py
+++ b/custom_components/redback_tech/text.py
@@ -51,9 +51,9 @@ class RedbackTechTextEntity(CoordinatorEntity, TextEntity):
             "text.rb"
             + self.ent_id[:4]
             + "_"
-            + self.ent_id[-3:].lower()
+            + self.ent_id[-3:].lower().replace(" ", "_")
             + "_"
-            + ENTITY_DETAILS[self.ent_key[7:]]["name"]
+            + ENTITY_DETAILS[self.ent_key[7:]]["name"].lower().replace(" ", "_")
         )
         LOGGER.debug("text_data1: %s", self.ent_data)
         LOGGER.debug("text_ent_id: %s", self.ent_id)


### PR DESCRIPTION
Fix to bug caused by Home Assistant 2026.2.0

## Summary by Sourcery

Bug Fixes:
- Prevent invalid entity IDs by lowercasing and replacing spaces with underscores in dynamically generated IDs across button, binary_sensor, number, select, sensor, text, datetime, and calendar entities.